### PR TITLE
Redesign portfolio with dark green theme based on new Figma design

### DIFF
--- a/src/_includes/layouts/base.html
+++ b/src/_includes/layouts/base.html
@@ -10,8 +10,8 @@
   <link rel="stylesheet" href="/global.css">
 </head>
 
-<body class="text-gray-800">
-  <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-amber-600 focus:text-white focus:rounded">Skip to main content</a>
+<body class="bg-[#0a0f0d] text-[#e8f5e9]">
+  <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:bg-green-600 focus:text-white focus:rounded">Skip to main content</a>
   {% include "partials/site-header.html" %}
 
   <main tabindex="-1" id="main-content" class="flex flex-col max-w-screen-xl mx-auto w-11/12 sm:w-10/12">

--- a/src/_includes/layouts/index.html
+++ b/src/_includes/layouts/index.html
@@ -1,30 +1,112 @@
 {% extends "layouts/base.html" %}
 
-{% set pageHeaderTitle = title %}
-{% set pageHeaderSummary = summary %}
-
 {% block content %}
-<div id="hero" class="hero fade-in flex flex-col justify-center pa-4" style="min-height: 400px;">
-  <div class="flex">
-    <img src="images/about/cover.png" alt="">
-  </div>
-  <div class="hero__inner flex flex-col pt-8 pb-12">
-    <h1 class="text-7xl leading-none mb-6 order-2 font-serif font-medium">Welcome to my world!</h1>
-    <p class="uppercase font-bold mb-4 text-xl order-1 text-amber-600">
-      Hej, My name is Son
-    </p>
-    <div class="text-2xl font-light leading-snug order-3">
-      <p class="m-0">
-        As a dynamic digital transformer who focuses on human rights, diversity, inclusion, and digital creativity, I have worked for more than six years in diverse organizations and business models. For me, communication and technology are a rope connecting people, and together we spread positivity.
+
+<!-- Hero -->
+<section id="hero" class="py-20 px-0">
+  <div class="flex flex-col lg:flex-row gap-16 items-start">
+
+    <!-- Left: Text -->
+    <div class="flex flex-col gap-6 flex-1">
+      <div class="flex flex-col gap-4">
+        <h1 class="text-6xl font-normal leading-tight text-[#e8f5e9]">Xin Chào!</h1>
+        <h1 class="text-6xl font-normal leading-tight">
+          I'm <span class="text-[#22c55e]">Son Nguyen</span>
+        </h1>
+        <!-- Animated role badge -->
+        <div class="flex items-center gap-2">
+          <span class="w-1 h-1 rounded-full bg-[#22c55e]"></span>
+          <span class="inline-flex items-center px-3 py-1 rounded-xl bg-[#22c55e] text-[#052e16] text-lg font-medium">
+            Growth Marketing Strategist
+          </span>
+        </div>
+      </div>
+
+      <p class="text-[#94a3b8] text-lg leading-relaxed max-w-lg">
+        Welcome to my journey where <strong class="text-[#22c55e] font-medium">growth marketing meets sustainable impact</strong>.
+        With a Master's in Environmental Science and expertise in UX Writing + Communications Strategy,
+        I help brands grow authentically while making a positive difference. 🌱📈
       </p>
+
+      <div class="section-card p-4">
+        <p class="text-[#e8f5e9] text-sm leading-relaxed">
+          <strong class="text-[#22c55e]">My creative toolkit?</strong>
+          From short-form video and content creation to strategic UX writing and communications,
+          I turn complex ideas into compelling brand stories. Whether it's Instagram Reels, campaign videos,
+          or conversion-focused copy – I create content that doesn't just convert, it connects. 🎬💫
+        </p>
+      </div>
+    </div>
+
+    <!-- Right: CTA card -->
+    <div class="flex flex-col gap-6 flex-1 lg:max-w-sm w-full">
+      <!-- Placeholder embed area -->
+      <div class="rounded-2xl bg-gradient-to-br from-[rgba(34,197,94,0.1)] to-[rgba(22,163,74,0.05)] h-48 flex items-center justify-center border border-[rgba(34,197,94,0.15)]">
+        <span class="text-[#94a3b8] text-sm">Content Preview</span>
+      </div>
+
+      <!-- CTA Card -->
+      <div class="section-card p-4 flex flex-col gap-4">
+        <p class="text-[#e8f5e9] text-sm font-medium text-center">Ready to explore?</p>
+        <div class="grid grid-cols-2 gap-2">
+          <a href="#creative-work" class="btn-primary text-xs py-2">View Creative Work</a>
+          <a href="/projects/" class="btn-outline text-xs py-2">View Projects</a>
+          <a href="#contact" class="btn-outline text-xs py-2">Contact Me</a>
+          <a href="/resources/Son_Nguyen_CV.pdf" class="bg-[#16a34a] text-[#f0fdf4] inline-flex items-center justify-center font-medium px-3 py-2 rounded-[10px] text-xs transition-all hover:bg-[#15803d]">Download CV</a>
+        </div>
+        <div class="border-t border-[rgba(34,197,94,0.1)] pt-4 flex flex-col gap-3">
+          <p class="text-[#e8f5e9] text-xs font-medium text-center">Connect with me</p>
+          <div class="flex items-center justify-center gap-3">
+            <a href="https://www.linkedin.com/in/jenson3006/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"
+               class="flex items-center justify-center w-[46px] h-[46px] rounded-xl section-card hover:border-[rgba(34,197,94,0.3)] transition-all">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+            </a>
+            <a href="https://www.instagram.com/foodstuckers.sthlm/" target="_blank" rel="noopener noreferrer" aria-label="Instagram"
+               class="flex items-center justify-center w-[46px] h-[46px] rounded-xl section-card hover:border-[rgba(34,197,94,0.3)] transition-all">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
+            </a>
+            <a href="https://github.com/JensonNg" target="_blank" rel="noopener noreferrer" aria-label="GitHub"
+               class="flex items-center justify-center w-[46px] h-[46px] rounded-xl section-card hover:border-[rgba(34,197,94,0.3)] transition-all">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+            </a>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
-</div>
 
-{% include "partials/featured-projects.html" %}
+  <!-- Scroll indicator -->
+  <div class="flex justify-center mt-16">
+    <a href="#about" class="flex items-center justify-center w-10 h-10 rounded-full text-[#94a3b8] hover:text-[#22c55e] transition-all">
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><polyline points="19 12 12 19 5 12"></polyline></svg>
+    </a>
+  </div>
+</section>
+
+{% include "partials/about-me.html" %}
+
+{% include "partials/content-creation.html" %}
+
+{% include "partials/education.html" %}
 
 {% include "partials/experience.html" %}
 
-{% include "partials/education.html" %}
+{% include "partials/skills.html" %}
+
+{% include "partials/featured-projects.html" %}
+
+<!-- CV Download -->
+<section class="py-12 text-center">
+  <p class="text-[#94a3b8] mb-6 max-w-md mx-auto">Get the full details of my professional background, experience, and skills in one document.</p>
+  <div class="flex flex-col items-center gap-3">
+    <a href="/resources/Son_Nguyen_CV.pdf" class="btn-primary gap-2 px-6 py-2.5">
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+      Download CV
+    </a>
+    <span class="text-[#94a3b8] text-xs">PDF format • Updated January 2025 • 2 pages</span>
+  </div>
+</section>
+
+{% include "partials/contact.html" %}
 
 {% endblock %}

--- a/src/_includes/partials/about-me.html
+++ b/src/_includes/partials/about-me.html
@@ -1,0 +1,115 @@
+<section id="about" class="mb-6">
+  <div class="section-card">
+    <!-- Section Header -->
+    <div class="section-card__header">
+      <div class="flex items-center gap-6">
+        <div class="flex items-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>
+          <span class="badge">About Me</span>
+        </div>
+        <div>
+          <h2 class="text-2xl font-semibold text-[#e8f5e9]">About Me</h2>
+          <p class="text-[#94a3b8] text-sm mt-0.5">Growth Marketing meets Sustainable Impact – Learn about my journey</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section Body -->
+    <div class="section-card__body">
+      <div class="flex flex-col lg:flex-row gap-10">
+
+        <!-- Left: Bio text -->
+        <div class="flex-1 flex flex-col gap-8">
+          <p class="text-[#94a3b8] leading-relaxed">
+            I'm a Growth Marketing Strategist who bridges conventional marketing with sustainable impact. With a background spanning environmental science, UX writing, and content creation, I bring a unique perspective to brand storytelling – one that balances authentic connection with measurable growth.
+          </p>
+
+          <div>
+            <h3 class="text-lg font-medium text-[#e8f5e9] mb-1">
+              My <span class="text-[#22c55e] underline decoration-dotted">Creative Approach</span>
+            </h3>
+            <p class="text-[#94a3b8] leading-relaxed text-sm mt-3">
+              I combine UX Writing principles with growth strategy to create content that doesn't just look good – it performs. Every piece of content I create is rooted in user psychology, data insights, and authentic storytelling.
+            </p>
+            <p class="text-[#94a3b8] leading-relaxed text-sm mt-3">
+              My environmental science background gives me a unique ability to translate complex, technical information into compelling narratives. I excel at finding the human story within data-driven challenges and making it resonate with diverse audiences.
+            </p>
+          </div>
+        </div>
+
+        <!-- Right: Photo + Stats + Differentiators -->
+        <div class="flex flex-col gap-6 lg:w-96">
+          <!-- Profile photo -->
+          <div class="rounded-2xl overflow-hidden aspect-video lg:aspect-auto lg:h-64 bg-[rgba(34,197,94,0.05)] border border-[rgba(34,197,94,0.1)] flex items-center justify-center">
+            <img src="/images/about/profile_image.jpg" alt="Son Nguyen" class="w-full h-full object-cover rounded-2xl">
+          </div>
+
+          <!-- Stats -->
+          <div class="section-card p-4">
+            <p class="text-[#e8f5e9] text-sm font-medium text-center mb-4">My Impact by Numbers</p>
+            <div class="grid grid-cols-2 gap-4">
+              <div class="text-center">
+                <p class="text-2xl font-bold text-[#22c55e]">6+</p>
+                <p class="text-[#94a3b8] text-xs">Years Experience</p>
+              </div>
+              <div class="text-center">
+                <p class="text-2xl font-bold text-[#22c55e]">1500+</p>
+                <p class="text-[#94a3b8] text-xs">Blog Followers</p>
+              </div>
+              <div class="text-center">
+                <p class="text-2xl font-bold text-[#22c55e]">8+</p>
+                <p class="text-[#94a3b8] text-xs">Organizations</p>
+              </div>
+              <div class="text-center">
+                <p class="text-2xl font-bold text-[#22c55e]">3</p>
+                <p class="text-[#94a3b8] text-xs">Languages</p>
+              </div>
+            </div>
+          </div>
+
+          <!-- What makes me different -->
+          <div class="section-card p-4">
+            <p class="text-[#e8f5e9] text-sm font-medium mb-4">What makes me different?</p>
+            <ul class="flex flex-col gap-4">
+              <li class="flex items-start gap-3">
+                <svg class="mt-0.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                <div>
+                  <p class="text-[#e8f5e9] text-sm font-medium">Content Creation &amp; Video Editing</p>
+                  <p class="text-[#94a3b8] text-xs">Short-form video, Reels, and visual storytelling</p>
+                </div>
+              </li>
+              <li class="flex items-start gap-3">
+                <svg class="mt-0.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                <div>
+                  <p class="text-[#e8f5e9] text-sm font-medium">Strategic UX Writing</p>
+                  <p class="text-[#94a3b8] text-xs">Converting copy that connects with users</p>
+                </div>
+              </li>
+              <li class="flex items-start gap-3">
+                <svg class="mt-0.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                <div>
+                  <p class="text-[#e8f5e9] text-sm font-medium">Sustainable Growth Focus</p>
+                  <p class="text-[#94a3b8] text-xs">Long-term brand building over quick wins</p>
+                </div>
+              </li>
+              <li class="flex items-start gap-3">
+                <svg class="mt-0.5 shrink-0" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                <div>
+                  <p class="text-[#e8f5e9] text-sm font-medium">Environmental Science Background</p>
+                  <p class="text-[#94a3b8] text-xs">Complex ideas made simple &amp; compelling</p>
+                </div>
+              </li>
+            </ul>
+            <div class="mt-5 pt-4 border-t border-[rgba(255,255,255,0.08)]">
+              <a href="#experience" class="flex items-center gap-1 text-[#22c55e] text-sm font-medium hover:gap-2 transition-all">
+                See My Experience
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/_includes/partials/contact.html
+++ b/src/_includes/partials/contact.html
@@ -1,0 +1,115 @@
+<section id="contact" class="mb-6 py-8">
+  <div class="flex flex-col lg:flex-row gap-8">
+
+    <!-- Left: Contact info -->
+    <div class="flex-1 flex flex-col gap-6">
+      <p class="text-[#94a3b8] leading-relaxed">
+        Feel free to reach out through any of these methods – I'm always open to discussing new opportunities, collaborations, or just a good conversation about marketing and sustainability.
+      </p>
+
+      <div class="flex flex-col gap-4">
+        <div class="section-card p-4">
+          <div class="flex items-center gap-4">
+            <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-[rgba(34,197,94,0.1)]">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path><polyline points="22,6 12,13 2,6"></polyline></svg>
+            </div>
+            <div>
+              <p class="text-[#94a3b8] text-xs">Email</p>
+              <a href="mailto:sonngoc.nguyen@hyperisland.se" class="text-[#e8f5e9] text-sm hover:text-[#22c55e] transition-colors">sonngoc.nguyen@hyperisland.se</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="section-card p-4">
+          <div class="flex items-center gap-4">
+            <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-[rgba(34,197,94,0.1)]">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.77 13a19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 3.68 2h3a2 2 0 0 1 2 1.72 12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"></path></svg>
+            </div>
+            <div>
+              <p class="text-[#94a3b8] text-xs">Phone</p>
+              <a href="tel:+46767666509" class="text-[#e8f5e9] text-sm hover:text-[#22c55e] transition-colors">+46 767 666 509</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="section-card p-4">
+          <div class="flex items-center gap-4">
+            <div class="flex items-center justify-center w-8 h-8 rounded-lg bg-[rgba(34,197,94,0.1)]">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path><circle cx="12" cy="10" r="3"></circle></svg>
+            </div>
+            <div>
+              <p class="text-[#94a3b8] text-xs">Location</p>
+              <p class="text-[#e8f5e9] text-sm">Stockholm, Sweden</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <p class="text-[#e8f5e9] text-sm font-medium mb-3">Areas of Collaboration</p>
+        <div class="flex flex-wrap gap-2">
+          <span class="badge">Growth Marketing</span>
+          <span class="badge">Sustainability Strategy</span>
+          <span class="badge">UX Research</span>
+          <span class="badge">Content Creation</span>
+          <span class="badge">Brand Development</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Right: Contact form -->
+    <div class="flex-1">
+      <div class="section-card p-6">
+        <form class="flex flex-col gap-5" action="https://formspree.io/f/placeholder" method="POST">
+          <div class="grid grid-cols-2 gap-4">
+            <div class="flex flex-col gap-1.5">
+              <label class="text-[#e8f5e9] text-xs font-medium" for="contact-name">Name</label>
+              <input
+                id="contact-name"
+                name="name"
+                type="text"
+                placeholder="Your name"
+                class="bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)] rounded-lg px-3 py-2 text-sm text-[#e8f5e9] placeholder-[#94a3b8] focus:outline-none focus:border-[rgba(34,197,94,0.4)] transition-colors"
+              >
+            </div>
+            <div class="flex flex-col gap-1.5">
+              <label class="text-[#e8f5e9] text-xs font-medium" for="contact-email">Email</label>
+              <input
+                id="contact-email"
+                name="email"
+                type="email"
+                placeholder="your@email.com"
+                class="bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)] rounded-lg px-3 py-2 text-sm text-[#e8f5e9] placeholder-[#94a3b8] focus:outline-none focus:border-[rgba(34,197,94,0.4)] transition-colors"
+              >
+            </div>
+          </div>
+          <div class="flex flex-col gap-1.5">
+            <label class="text-[#e8f5e9] text-xs font-medium" for="contact-subject">Subject</label>
+            <input
+              id="contact-subject"
+              name="subject"
+              type="text"
+              placeholder="What would you like to discuss?"
+              class="bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)] rounded-lg px-3 py-2 text-sm text-[#e8f5e9] placeholder-[#94a3b8] focus:outline-none focus:border-[rgba(34,197,94,0.4)] transition-colors"
+            >
+          </div>
+          <div class="flex flex-col gap-1.5">
+            <label class="text-[#e8f5e9] text-xs font-medium" for="contact-message">Message</label>
+            <textarea
+              id="contact-message"
+              name="message"
+              rows="4"
+              placeholder="Tell me about your project or idea..."
+              class="bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)] rounded-lg px-3 py-2 text-sm text-[#e8f5e9] placeholder-[#94a3b8] focus:outline-none focus:border-[rgba(34,197,94,0.4)] transition-colors resize-none"
+            ></textarea>
+          </div>
+          <button type="submit" class="btn-primary w-full py-2.5 gap-2">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"></line><polygon points="22 2 15 22 11 13 2 9 22 2"></polygon></svg>
+            Send Message
+          </button>
+        </form>
+      </div>
+    </div>
+
+  </div>
+</section>

--- a/src/_includes/partials/content-creation.html
+++ b/src/_includes/partials/content-creation.html
@@ -1,0 +1,164 @@
+<section id="creative-work" class="mb-6">
+  <div class="section-card">
+    <!-- Section Header -->
+    <div class="section-card__header">
+      <div class="flex items-center gap-6">
+        <div class="flex items-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="23 7 16 12 23 17 23 7"></polygon><rect x="1" y="5" width="15" height="14" rx="2" ry="2"></rect></svg>
+          <span class="badge">Creative Work</span>
+        </div>
+        <div>
+          <h2 class="text-2xl font-semibold text-[#e8f5e9]">Content Creation</h2>
+          <p class="text-[#94a3b8] text-sm mt-0.5">Short-form video, content creation, and visual storytelling</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section Body -->
+    <div class="section-card__body flex flex-col gap-10">
+
+      <!-- Instagram Reels -->
+      <div>
+        <div class="flex items-center gap-4 mb-6">
+          <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)]">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold text-[#e8f5e9]">Instagram Reels</h3>
+            <p class="text-[#94a3b8] text-sm">@foodstuckers.sthlm</p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div class="rounded-xl overflow-hidden border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] group relative aspect-square">
+            <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all bg-[rgba(10,15,13,0.5)] z-10">
+              <div class="flex items-center justify-center w-16 h-16 rounded-full bg-[rgba(34,197,94,0.2)] border border-[rgba(34,197,94,0.3)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="#22c55e" stroke="#22c55e" stroke-width="1"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+              </div>
+            </div>
+            <div class="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[rgba(10,15,13,0.9)] to-transparent">
+              <p class="text-[#e8f5e9] text-sm font-medium">Coffee in Paris Review</p>
+            </div>
+            <div class="w-full h-full bg-[rgba(34,197,94,0.05)] flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="rgba(34,197,94,0.2)" stroke-width="1"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path></svg>
+            </div>
+          </div>
+
+          <div class="rounded-xl overflow-hidden border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] group relative aspect-square">
+            <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all bg-[rgba(10,15,13,0.5)] z-10">
+              <div class="flex items-center justify-center w-16 h-16 rounded-full bg-[rgba(34,197,94,0.2)] border border-[rgba(34,197,94,0.3)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="#22c55e" stroke="#22c55e" stroke-width="1"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+              </div>
+            </div>
+            <div class="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[rgba(10,15,13,0.9)] to-transparent">
+              <p class="text-[#e8f5e9] text-sm font-medium">RFSL Interview – EATHAN Representative</p>
+            </div>
+            <div class="w-full h-full bg-[rgba(34,197,94,0.05)] flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="rgba(34,197,94,0.2)" stroke-width="1"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path></svg>
+            </div>
+          </div>
+
+          <div class="rounded-xl overflow-hidden border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] group relative aspect-square">
+            <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all bg-[rgba(10,15,13,0.5)] z-10">
+              <div class="flex items-center justify-center w-16 h-16 rounded-full bg-[rgba(34,197,94,0.2)] border border-[rgba(34,197,94,0.3)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="#22c55e" stroke="#22c55e" stroke-width="1"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+              </div>
+            </div>
+            <div class="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[rgba(10,15,13,0.9)] to-transparent">
+              <p class="text-[#e8f5e9] text-sm font-medium">Vietnam in my memory</p>
+            </div>
+            <div class="w-full h-full bg-[rgba(34,197,94,0.05)] flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="rgba(34,197,94,0.2)" stroke-width="1"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path></svg>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex justify-center mt-4">
+          <a href="https://www.instagram.com/foodstuckers.sthlm/" target="_blank" rel="noopener noreferrer"
+             class="flex items-center gap-2 text-[#22c55e] text-sm font-medium hover:underline">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
+            View All on Instagram
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
+          </a>
+        </div>
+      </div>
+
+      <!-- Divider -->
+      <div class="border-t border-[rgba(255,255,255,0.08)]"></div>
+
+      <!-- LinkedIn Posts -->
+      <div>
+        <div class="flex items-center gap-4 mb-6">
+          <div class="flex items-center justify-center w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)]">
+            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+          </div>
+          <div>
+            <h3 class="text-xl font-semibold text-[#e8f5e9]">LinkedIn Posts</h3>
+            <p class="text-[#94a3b8] text-sm">Professional Content</p>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div class="rounded-xl overflow-hidden border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] group relative aspect-square">
+            <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all bg-[rgba(10,15,13,0.5)] z-10">
+              <div class="flex items-center justify-center w-16 h-16 rounded-full bg-[rgba(34,197,94,0.2)] border border-[rgba(34,197,94,0.3)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="#22c55e" stroke="#22c55e" stroke-width="1"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+              </div>
+            </div>
+            <div class="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[rgba(10,15,13,0.9)] to-transparent">
+              <p class="text-[#e8f5e9] text-sm font-medium">Trade Finance Facts – Mitigram</p>
+            </div>
+            <div class="w-full h-full bg-[rgba(34,197,94,0.05)] flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="rgba(34,197,94,0.2)" stroke-width="1"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+            </div>
+          </div>
+
+          <div class="rounded-xl overflow-hidden border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] group relative aspect-square">
+            <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all bg-[rgba(10,15,13,0.5)] z-10">
+              <div class="flex items-center justify-center w-16 h-16 rounded-full bg-[rgba(34,197,94,0.2)] border border-[rgba(34,197,94,0.3)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="#22c55e" stroke="#22c55e" stroke-width="1"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+              </div>
+            </div>
+            <div class="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[rgba(10,15,13,0.9)] to-transparent">
+              <p class="text-[#e8f5e9] text-sm font-medium">Breakdown the Steps – The Series</p>
+            </div>
+            <div class="w-full h-full bg-[rgba(34,197,94,0.05)] flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="rgba(34,197,94,0.2)" stroke-width="1"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+            </div>
+          </div>
+
+          <div class="rounded-xl overflow-hidden border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] group relative aspect-square">
+            <div class="absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all bg-[rgba(10,15,13,0.5)] z-10">
+              <div class="flex items-center justify-center w-16 h-16 rounded-full bg-[rgba(34,197,94,0.2)] border border-[rgba(34,197,94,0.3)]">
+                <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="#22c55e" stroke="#22c55e" stroke-width="1"><polygon points="5 3 19 12 5 21 5 3"></polygon></svg>
+              </div>
+            </div>
+            <div class="absolute bottom-0 left-0 right-0 p-3 bg-gradient-to-t from-[rgba(10,15,13,0.9)] to-transparent">
+              <p class="text-[#e8f5e9] text-sm font-medium">Webinar Highlight Series</p>
+            </div>
+            <div class="w-full h-full bg-[rgba(34,197,94,0.05)] flex items-center justify-center">
+              <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="rgba(34,197,94,0.2)" stroke-width="1"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+            </div>
+          </div>
+        </div>
+
+        <div class="flex justify-center mt-4">
+          <a href="https://www.linkedin.com/in/jenson3006/" target="_blank" rel="noopener noreferrer"
+             class="flex items-center gap-2 text-[#22c55e] text-sm font-medium hover:underline">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+            View All on LinkedIn
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
+          </a>
+        </div>
+      </div>
+
+      <!-- More content note -->
+      <div class="rounded-xl bg-[rgba(34,197,94,0.05)] border border-[rgba(34,197,94,0.1)] p-4">
+        <p class="text-[#94a3b8] text-sm text-center">
+          📹 <strong class="text-[#e8f5e9]">More Content Available:</strong> Additional video samples and content portfolio pieces are available upon request.
+        </p>
+      </div>
+
+    </div>
+  </div>
+</section>

--- a/src/_includes/partials/education.html
+++ b/src/_includes/partials/education.html
@@ -1,55 +1,79 @@
-<div id="featured-projects" class="flex flex-col mb-20">
+<section id="education" class="mb-6">
+  <div class="section-card">
+    <!-- Section Header -->
+    <div class="section-card__header">
+      <div class="flex items-center gap-6">
+        <div class="flex items-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 10v6M2 10l10-5 10 5-10 5z"></path><path d="M6 12v5c3 3 9 3 12 0v-5"></path></svg>
+          <span class="badge">Education</span>
+        </div>
+        <div>
+          <h2 class="text-2xl font-semibold text-[#e8f5e9]">Education</h2>
+          <p class="text-[#94a3b8] text-sm mt-0.5">Academic background in Environmental Science and Communications</p>
+        </div>
+      </div>
+    </div>
 
+    <!-- Section Body -->
+    <div class="section-card__body flex flex-col gap-4">
 
-  <section id="education" class="w-full pt-4 pb-8">
-    <h2 class="font-serif text-3xl mb-6">Education</h2>
-    <a href="https://www.sh.se/english/sodertorn-university" target="_blank" class="bg-white border-4 border-transparent hover:border-amber-200 shadow-sm hover:shadow-md p-4 rounded-md flex mb-4">
-      <div class="flex-shrink-0 flex-grow-0">
-        <span class="inline-block w-12 mr-2">
-          <object data="images/about/sodertorn_logo.png" alt="Sodertorn" class="block mx-auto w-10/12"></object>
-        </span>
-      </div>
-      <div class="sm:w-full sm:border-none md:border-r-2 md:border-dotted md:border-gray-300 pr-2">
-        <p class="font-bold text-gray-900">Södertörn University</p>
-        <p class="font-normal text-gray-700">Master in Environmental Science of Infectious Disease Control</p>
-      </div>
-      <div class="w-2/5 xs:w-full">
-        <p class="text-right text-gray-700 font-light">Aug 2021 - Aug 2022</p>
-        <p class="text-right text-gray-700 font-light">Stockholm, Sweden</p>
-      </div>
-    </a>
+      <a href="https://www.sh.se/english/sodertorn-university" target="_blank" rel="noopener noreferrer"
+         class="flex flex-col sm:flex-row gap-4 items-start p-4 rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all">
+        <div class="shrink-0">
+          <div class="w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.08)] flex items-center justify-center overflow-hidden">
+            <object data="/images/about/sodertorn_logo.png" type="image/png" class="w-10 h-10 object-contain">
+              <span class="text-[#94a3b8] text-xs font-bold">SH</span>
+            </object>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[#e8f5e9] font-medium">Södertörn University</p>
+          <p class="text-[#94a3b8] text-sm">Master in Environmental Science of Infectious Disease Control</p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-[#94a3b8] text-sm">Aug 2021 – Aug 2022</p>
+          <p class="text-[#94a3b8] text-xs">Stockholm, Sweden</p>
+        </div>
+      </a>
 
-    <a href="https://hermods.se/" target="_blank" class="bg-white border-4 border-transparent hover:border-amber-200 shadow-sm hover:shadow-md p-4 rounded-md flex mb-4">
-      <div class="flex-shrink-0 flex-grow-0">
-        <span class="inline-block w-12 mr-2">
-          <object data="images/about/Hermods_Logo.png" alt="Hermods" class="block mx-auto w-10/12"></object>
-        </span>
-      </div>
-      <div class="sm:w-full sm:border-none md:border-r-2 md:border-dotted md:border-gray-300 pr-2">
-        <p class="font-bold text-gray-900">Hermods AB</p>
-        <p class="font-normal text-gray-700">Language Programs (Swedish, English) </p>
-      </div>
-      <div class="w-2/5 xs:w-full">
-        <p class="text-right text-gray-700 font-light">Sep 2020 - Jun 2021</p>
-        <p class="text-right text-gray-700 font-light">Stockholm, Sweden</p>
-      </div>
-    </a>
+      <a href="https://hermods.se/" target="_blank" rel="noopener noreferrer"
+         class="flex flex-col sm:flex-row gap-4 items-start p-4 rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all">
+        <div class="shrink-0">
+          <div class="w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.08)] flex items-center justify-center overflow-hidden">
+            <object data="/images/about/Hermods_Logo.png" type="image/png" class="w-10 h-10 object-contain">
+              <span class="text-[#94a3b8] text-xs font-bold">HM</span>
+            </object>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[#e8f5e9] font-medium">Hermods AB</p>
+          <p class="text-[#94a3b8] text-sm">Language Programs (Swedish, English)</p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-[#94a3b8] text-sm">Sep 2020 – Jun 2021</p>
+          <p class="text-[#94a3b8] text-xs">Stockholm, Sweden</p>
+        </div>
+      </a>
 
-    <a href="http://en.hunre.edu.vn/hunre-en/trang-chu" target="_blank" class="bg-white border-4 border-transparent hover:border-amber-200 shadow-sm hover:shadow-md p-4 rounded-md flex mb-4">
-      <div class="flex-shrink-0 flex-grow-0">
-        <span class="inline-block w-12 mr-2">
-          <object data="images/about/hunre_university_logo.png" alt="HUNRE" class="block mx-auto w-10/12"></object>
-        </span>
-      </div>
-      <div class="sm:w-full sm:border-none md:border-r-2 md:border-dotted md:border-gray-300 pr-2">
-        <p class="font-bold text-gray-900"> Hanoi University of Natural Recources and Environment</p>
-        <p class="font-normal text-gray-700"> Engineer Degree in Marine Management</p>
-      </div>
-      <div class="w-2/5 xs:w-full">
-        <p class="text-right text-gray-700 font-light">Aug 2014 - Jun 2018</p>
-        <p class="text-right text-gray-700 font-light">Hanoi, Vietnam</p>
-      </div>
-    </a>
-  </section>
+      <a href="http://en.hunre.edu.vn/hunre-en/trang-chu" target="_blank" rel="noopener noreferrer"
+         class="flex flex-col sm:flex-row gap-4 items-start p-4 rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all">
+        <div class="shrink-0">
+          <div class="w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.08)] flex items-center justify-center overflow-hidden">
+            <object data="/images/about/hunre_university_logo.png" type="image/png" class="w-10 h-10 object-contain">
+              <span class="text-[#94a3b8] text-xs font-bold">HU</span>
+            </object>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[#e8f5e9] font-medium">Hanoi University of Natural Resources and Environment</p>
+          <p class="text-[#94a3b8] text-sm">Engineer Degree in Marine Management</p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-[#94a3b8] text-sm">Aug 2014 – Jun 2018</p>
+          <p class="text-[#94a3b8] text-xs">Hanoi, Vietnam</p>
+        </div>
+      </a>
 
-</div>
+    </div>
+  </div>
+</section>

--- a/src/_includes/partials/experience.html
+++ b/src/_includes/partials/experience.html
@@ -1,89 +1,112 @@
-<div id="experience" class="flex flex-col mb-20">
-
-
-  <section id="education" class="w-full pt-4 pb-8">
-    <h2 class="font-serif text-3xl mb-6">Experience</h2>
-
-    <div class="bg-white shadow-sm hover:shadow-md p-4 rounded-md flex mb-4 pr-2 border-4 border-transparent hover:border-amber-200">
-      <div class="flex-shrink-0 flex-grow-0">
-        <span class="inline-block w-12 mr-2">
-          <object data="images/about/itAgenturen_logo.png" alt="itAgenturen" class="block mx-auto w-10/12"></object>
-        </span>
-      </div>
-      <div class="w-2/3 sm:w-full sm:border-none md:border-r-2 md:border-dotted md:border-gray-300">
-        <p class="font-bold text-gray-900">Content Developer</p>
-        <p class="font-normal text-gray-700">itAgenturen</p>
-      </div>
-      <div class="w-1/3 xs:w-full">
-        <p class="font-light text-right text-gray-600">Jan, 2023 - Present</p>
-        <p class="font-light text-right text-gray-600">Stockholm, Sweden</p>
+<section id="experience" class="mb-6">
+  <div class="section-card">
+    <!-- Section Header -->
+    <div class="section-card__header">
+      <div class="flex items-center gap-6">
+        <div class="flex items-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path></svg>
+          <span class="badge">Experience</span>
+        </div>
+        <div>
+          <h2 class="text-2xl font-semibold text-[#e8f5e9]">Experience</h2>
+          <p class="text-[#94a3b8] text-sm mt-0.5">Latest work experience in Growth Marketing and Communications</p>
+        </div>
       </div>
     </div>
 
-    <div class="bg-white shadow-sm hover:shadow-md p-4 rounded-md flex mb-4 pr-2 border-4 border-transparent hover:border-amber-200">
-      <div class="flex-shrink-0 flex-grow-0">
-        <span class="inline-block w-12 mr-2">
-          <object data="images/about/RFSL_logo.jpeg" alt="RFSL" class="block mx-auto w-10/12"></object>
-        </span>
-      </div>
-      <div class="w-2/3 sm:w-full sm:border-none md:border-r-2 md:border-dotted md:border-gray-300">
-        <p class="font-bold text-gray-900">Assistant Communication Officer and Content Creator</p>
-        <p class="font-normal text-gray-700">RFSL</p>
-      </div>
-      <div class="w-1/3 xs:w-full">
-        <p class="font-light text-right text-gray-600">Aug, 2022 - Present</p>
-        <p class="font-light text-right text-gray-600">Stockholm, Sweden</p>
-      </div>
-    </div>
+    <!-- Section Body -->
+    <div class="section-card__body flex flex-col gap-4">
 
-  <div class="bg-white shadow-sm hover:shadow-md p-4 rounded-md flex mb-4 pr-2 border-4 border-transparent hover:border-amber-200">
-    <div class="flex-shrink-0 flex-grow-0">
-      <span class="inline-block w-12 mr-2">
-        <object data="images/about/seedplanter_logo.png" alt="Seed Planter" class="block mx-auto w-10/12"></object>
-      </span>
-    </div>
-    <div class="w-2/3 sm:w-full sm:border-none md:border-r-2 md:border-dotted md:border-gray-300">
-      <p class="font-bold text-gray-900">Designer and Media Team Leader</p>
-      <p class="font-normal text-gray-700">Seed Planter (Remote)</p>
-    </div>
-    <div class="w-1/3 xs:w-full">
-      <p class="font-light text-right text-gray-600">Feb, 2021 - Apr, 2022</p>
-      <p class="font-light text-right text-gray-600">Vietnam</p>
+      <div class="flex flex-col sm:flex-row gap-4 items-start p-4 rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all">
+        <div class="shrink-0">
+          <div class="w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.08)] flex items-center justify-center overflow-hidden">
+            <object data="/images/about/itAgenturen_logo.png" type="image/png" class="w-10 h-10 object-contain">
+              <span class="text-[#94a3b8] text-xs font-bold">iA</span>
+            </object>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[#e8f5e9] font-medium">Content Developer</p>
+          <p class="text-[#94a3b8] text-sm">itAgenturen</p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-[#94a3b8] text-sm">Jan 2023 – Present</p>
+          <p class="text-[#94a3b8] text-xs">Stockholm, Sweden</p>
+        </div>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-4 items-start p-4 rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all">
+        <div class="shrink-0">
+          <div class="w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.08)] flex items-center justify-center overflow-hidden">
+            <object data="/images/about/RFSL_logo.jpeg" type="image/jpeg" class="w-10 h-10 object-contain">
+              <span class="text-[#94a3b8] text-xs font-bold">RF</span>
+            </object>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[#e8f5e9] font-medium">Assistant Communication Officer &amp; Content Creator</p>
+          <p class="text-[#94a3b8] text-sm">RFSL</p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-[#94a3b8] text-sm">Aug 2022 – Present</p>
+          <p class="text-[#94a3b8] text-xs">Stockholm, Sweden</p>
+        </div>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-4 items-start p-4 rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all">
+        <div class="shrink-0">
+          <div class="w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.08)] flex items-center justify-center overflow-hidden">
+            <object data="/images/about/seedplanter_logo.png" type="image/png" class="w-10 h-10 object-contain">
+              <span class="text-[#94a3b8] text-xs font-bold">SP</span>
+            </object>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[#e8f5e9] font-medium">Designer &amp; Media Team Leader</p>
+          <p class="text-[#94a3b8] text-sm">Seed Planter (Remote)</p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-[#94a3b8] text-sm">Feb 2021 – Apr 2022</p>
+          <p class="text-[#94a3b8] text-xs">Vietnam</p>
+        </div>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-4 items-start p-4 rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all">
+        <div class="shrink-0">
+          <div class="w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.08)] flex items-center justify-center overflow-hidden">
+            <object data="/images/about/greenhub_logo.png" type="image/png" class="w-10 h-10 object-contain">
+              <span class="text-[#94a3b8] text-xs font-bold">GH</span>
+            </object>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[#e8f5e9] font-medium">Field Officer | Communication Officer</p>
+          <p class="text-[#94a3b8] text-sm">Centre for Supporting Green Development (GreenHub)</p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-[#94a3b8] text-sm">2018 – 2019</p>
+          <p class="text-[#94a3b8] text-xs">Ha Long – Hanoi, Vietnam</p>
+        </div>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-4 items-start p-4 rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all">
+        <div class="shrink-0">
+          <div class="w-12 h-12 rounded-xl bg-[rgba(255,255,255,0.05)] border border-[rgba(255,255,255,0.08)] flex items-center justify-center overflow-hidden">
+            <object data="/images/about/pacificenv_logo.jpeg" type="image/jpeg" class="w-10 h-10 object-contain">
+              <span class="text-[#94a3b8] text-xs font-bold">PE</span>
+            </object>
+          </div>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="text-[#e8f5e9] font-medium">Waste Management Local Expert</p>
+          <p class="text-[#94a3b8] text-sm">Pacific Environment</p>
+        </div>
+        <div class="text-right shrink-0">
+          <p class="text-[#94a3b8] text-sm">2018 – 2019</p>
+          <p class="text-[#94a3b8] text-xs">Cat Ba – Da Nang – Hoi An, Vietnam</p>
+        </div>
+      </div>
+
     </div>
   </div>
-
-    <div class="bg-white shadow-sm hover:shadow-md p-4 rounded-md flex mb-4 pr-2 border-4 border-transparent hover:border-amber-200">
-      <div class="flex-shrink-0 flex-grow-0">
-        <span class="inline-block w-12 mr-2">
-          <object data="images/about/greenhub_logo.png" alt="GreenHub" class="block mx-auto w-10/12"></object>
-        </span>
-      </div>
-      <div class="w-2/3 sm:w-full sm:border-none md:border-r-2 md:border-dotted md:border-gray-300">
-        <p class="font-bold text-gray-900">Field Officer | Communication Officer</p>
-        <p class="font-normal text-gray-700">Centre for Supporting Green Development (GreenHub)</p>
-      </div>
-      <div class="w-1/3 xs:w-full">
-        <p class="font-light text-right text-gray-600">2018 - 2019</p>
-        <p class="font-light text-right text-gray-600">Ha Long - Hanoi, Vietnam</p>
-      </div>
-    </div>
-
-  <div class="bg-white shadow-sm hover:shadow-md p-4 rounded-md flex mb-4 pr-2 border-4 border-transparent hover:border-amber-200">
-    <div class="flex-shrink-0 flex-grow-0">
-      <span class="inline-block w-12 mr-2">
-        <object data="images/about/pacificenv_logo.jpeg" alt="Pacific Environment" class="block mx-auto w-10/12"></object>
-      </span>
-    </div>
-    <div class="w-2/3 sm:w-full sm:border-none md:border-r-2 md:border-dotted md:border-gray-300">
-      <p class="font-bold text-gray-900">Waste Management Local Expert</p>
-      <p class="font-normal text-gray-700"> Pacific Environment </p>
-    </div>
-    <div class="w-1/3 xs:w-full">
-      <p class="font-light text-right text-gray-600">2018 - 2019</p>
-      <p class="font-light text-right text-gray-600">Cat Ba - Da Nang - Hoian, Vietnam</p>
-    </div>
-  </div>
-
-  </section>
-
-</div>
+</section>

--- a/src/_includes/partials/featured-projects.html
+++ b/src/_includes/partials/featured-projects.html
@@ -1,24 +1,48 @@
-<div id="featured-projects" class="flex flex-col mb-20">
-  <h2 class="font-serif text-3xl mb-6">Featured Projects</h2>
+<section id="featured-projects" class="mb-6">
+  <div class="section-card">
+    <!-- Section Header -->
+    <div class="section-card__header">
+      <div class="flex items-center gap-6">
+        <div class="flex items-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon></svg>
+          <span class="badge">Projects</span>
+        </div>
+        <div>
+          <h2 class="text-2xl font-semibold text-[#e8f5e9]">Featured Projects</h2>
+          <p class="text-[#94a3b8] text-sm mt-0.5">Recent work in sustainable marketing and brand development</p>
+        </div>
+      </div>
+    </div>
 
-  <ul role="list" class="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3">
-    {% for item in collections.featuredProjects %}
-    <li class="featured__item col-span-1 flex flex-col justify-between rounded-lg hover:shadow-md transition-all duration-100 bg-gray-50 cursor-pointer">
-      <div class="flex-1 flex flex-col overflow-hidden">
-        <div class="w-full block">
-          <img src="{{ item.data.socialImage }}" alt="" class="rounded-t-lg w-full item__img" loading="lazy">
-        </div>
-        <h3 class="text-xl font-sans font-semibold leading-tight pt-4 px-4 transition-colors duration-75 text-amber-600"><a href="{{ item.url }}">{{ item.data.title }}</a></h3>
-        <div class="flex flex-col p-4 overflow-hidden">
-          <p class="block h-28 max-h-32 overflow-ellipsis font-serif text-gray-500 text-base leading-snug">{{ item.data.summary | truncate(250)}}</p>
-        </div>
-      </div>
-      <div class="p-4">
-        {% for tag in item.data.tags %}
-        <span class="uppercase text-xs mr-2 mb-2 p-2 bg-amber-100 rounded text-amber-700">{{tag}}</span>
+    <!-- Section Body -->
+    <div class="section-card__body">
+      <ul role="list" class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {% for item in collections.featuredProjects %}
+        <li class="flex flex-col rounded-xl border border-[rgba(255,255,255,0.06)] hover:border-[rgba(34,197,94,0.2)] hover:bg-[rgba(34,197,94,0.02)] transition-all overflow-hidden group">
+          <div class="w-full overflow-hidden aspect-video bg-[rgba(255,255,255,0.02)]">
+            <img src="{{ item.data.socialImage }}" alt="{{ item.data.title }}" class="w-full h-full object-cover transition-all duration-300 filter grayscale group-hover:grayscale-0" loading="lazy">
+          </div>
+          <div class="flex flex-col gap-3 p-4 flex-1">
+            <h3 class="text-[#e8f5e9] font-medium leading-snug">
+              <a href="{{ item.url }}" class="hover:text-[#22c55e] transition-colors">{{ item.data.title }}</a>
+            </h3>
+            <p class="text-[#94a3b8] text-sm leading-relaxed line-clamp-3">{{ item.data.summary | truncate(200) }}</p>
+            <div class="flex flex-wrap gap-1.5 mt-auto">
+              {% for tag in item.data.tags %}
+              <span class="badge text-xs">{{ tag }}</span>
+              {% endfor %}
+            </div>
+          </div>
+        </li>
         {% endfor %}
+      </ul>
+
+      <div class="flex justify-center mt-6">
+        <a href="/projects/" class="btn-outline gap-2">
+          View All Projects
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"></line><polyline points="12 5 19 12 12 19"></polyline></svg>
+        </a>
       </div>
-    </li>
-    {% endfor %}
-  </ul>
-</div>
+    </div>
+  </div>
+</section>

--- a/src/_includes/partials/site-footer.html
+++ b/src/_includes/partials/site-footer.html
@@ -1,18 +1,56 @@
-<footer class="flex-none py-4 border-t border-gray-300 text-sm sm:text-base w-full">
-  <div class="footer__inner flex items-center w-11/12 sm:w-10/12 max-w-screen-xl mx-auto">
-    <p class="footer__item m-0 flex-auto pr-2 flex-shrink-0">
-      <strong>© 2025</strong>
-      <br>
-      <a href="/">Son Nguyen</a>
-    </p>
-    <p class="footer__item m-0 flex-auto pr-2 flex-shrink-0">
-      <strong>Social</strong>
-      <br>
-      <a href="https://www.instagram.com/foodstuckers.sthlm/" target="_blank" rel="noopener noreferrer">Instagram</a> / <a href="https://github.com/JensonNg" target="_blank" rel="noopener noreferrer">Github</a> / <a href="https://www.linkedin.com/in/jenson3006/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
-    </p>
-    <p class="footer__item m-0 flex-auto items-center pr-0 text-right text-gray-500">
-      Created with <a href="https://www.11ty.dev" target="_blank" rel="noopener noreferrer" class="text-amber-600">11ty</a>, <a href="https://tailwindcss.com/" target="_blank" rel="noopener noreferrer" class="text-amber-600">Tailwind</a>
-      and ♡ in Stockholm, Sweden.
-    </p>
+<footer class="border-t border-[rgba(255,255,255,0.08)] bg-[rgba(10,15,13,0.8)] mt-16">
+  <div class="max-w-screen-xl mx-auto px-4 py-12">
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-8 pb-8 border-b border-[rgba(255,255,255,0.08)]">
+
+      <!-- Brand + Address -->
+      <div class="flex flex-col gap-4">
+        <div class="flex items-center justify-center w-10 h-10 rounded-full bg-[rgba(34,197,94,0.1)] border border-[rgba(34,197,94,0.2)] text-[#22c55e] font-bold text-lg">
+          SN
+        </div>
+        <div class="flex items-start gap-2">
+          <svg class="shrink-0 mt-0.5" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#94a3b8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path><circle cx="12" cy="10" r="3"></circle></svg>
+          <address class="not-italic text-[#94a3b8] text-sm leading-relaxed">
+            Vega, Handen<br>
+            13648, Stockholm<br>
+            Sweden
+          </address>
+        </div>
+      </div>
+
+      <!-- Quick Links -->
+      <div class="flex flex-col gap-4">
+        <h3 class="text-[#e8f5e9] font-semibold">Quick Links</h3>
+        <nav class="flex flex-col gap-2">
+          <a href="#creative-work" class="text-[#94a3b8] text-sm hover:text-[#22c55e] transition-colors">Content Creation</a>
+          <a href="/projects/" class="text-[#94a3b8] text-sm hover:text-[#22c55e] transition-colors">Projects</a>
+          <a href="#contact" class="text-[#94a3b8] text-sm hover:text-[#22c55e] transition-colors">Contact</a>
+        </nav>
+      </div>
+
+      <!-- Connect -->
+      <div class="flex flex-col gap-4">
+        <h3 class="text-[#e8f5e9] font-semibold">Connect</h3>
+        <div class="flex gap-3">
+          <a href="https://www.instagram.com/foodstuckers.sthlm/" target="_blank" rel="noopener noreferrer" aria-label="Instagram"
+             class="flex items-center justify-center w-9 h-9 rounded-xl bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)] text-[#94a3b8] hover:text-[#22c55e] hover:border-[rgba(34,197,94,0.3)] transition-all">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
+          </a>
+          <a href="https://www.linkedin.com/in/jenson3006/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"
+             class="flex items-center justify-center w-9 h-9 rounded-xl bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)] text-[#94a3b8] hover:text-[#22c55e] hover:border-[rgba(34,197,94,0.3)] transition-all">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+          </a>
+          <a href="https://github.com/JensonNg" target="_blank" rel="noopener noreferrer" aria-label="GitHub"
+             class="flex items-center justify-center w-9 h-9 rounded-xl bg-[rgba(255,255,255,0.03)] border border-[rgba(255,255,255,0.08)] text-[#94a3b8] hover:text-[#22c55e] hover:border-[rgba(34,197,94,0.3)] transition-all">
+            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+          </a>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Copyright -->
+    <div class="pt-6 text-center">
+      <p class="text-[#94a3b8] text-sm">© 2026 Son Nguyen. Made with Love</p>
+    </div>
   </div>
 </footer>

--- a/src/_includes/partials/site-header.html
+++ b/src/_includes/partials/site-header.html
@@ -1,29 +1,39 @@
-<header class="header py-12" role="banner">
-  <div class="flex items-center justify-between mx-auto w-11/12 sm:w-10/12 max-w-screen-xl">
-    <a href="/" class="flex items-center" rel="home" aria-label="Go To Homepage">
-      <img src="/images/about/profile_image.jpg" alt="Son Nguyen" class="rounded-full mr-2" width="48" height="48">
-      <span class="font-bold text-base">Son Nguyen</span>
+<header class="sticky top-0 z-50 w-full border-b border-[rgba(255,255,255,0.08)] bg-[rgba(10,15,13,0.9)] backdrop-blur-sm" role="banner">
+  <div class="flex items-center justify-between mx-auto px-4 max-w-screen-xl h-[72px]">
+    <!-- Logo -->
+    <a href="/" class="flex items-center justify-center w-10 h-10 rounded-full bg-[rgba(34,197,94,0.1)] border border-[rgba(34,197,94,0.2)] text-[#22c55e] font-bold text-lg" rel="home" aria-label="Go To Homepage">
+      SN
     </a>
 
-    <div class="flex items-center">
-      <nav class="flex items-center" role="navigation" tabindex="-1">
-        <div class="nav__content">
-          <ul id="nav-menu" class="flex p-0 m-0 list-none">
-            {% for item in navigation.items %}
-            <li class="relative">
-              <a href="{{ item.url }}" class="flex items-top relative lowercase py-2 px-3" {{ helpers.getLinkActiveState(item.url, page.url) | safe }}>
-                <span class="block mr-2 font-bold" aria-hidden="true">{{ item.order }}</span>
-                {% if helpers.isActiveLink(item.url, page.url) %}
-                <span class="border-b-4 border-amber-100 text-amber-600 bg-amber-100">{{ item.text }}</span>
-                {% else %}
-                <span class="border-b-4 border-amber-100 text-amber-600">{{ item.text }}</span>
-                {% endif %}
-              </a>
-            </li>
-            {% endfor %}
-          </ul>
-        </div>
-      </nav>
+    <!-- Navigation -->
+    <nav class="hidden sm:flex items-center gap-1" role="navigation">
+      <a href="#about" class="flex items-center gap-1 px-4 py-2 rounded-lg text-[#94a3b8] hover:text-[#e8f5e9] hover:bg-[rgba(255,255,255,0.05)] transition-all text-sm font-medium">
+        My Information
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+      </a>
+      <a href="#creative-work" class="flex items-center gap-1 px-4 py-2 rounded-lg text-[#94a3b8] hover:text-[#e8f5e9] hover:bg-[rgba(255,255,255,0.05)] transition-all text-sm font-medium">
+        My Work
+        <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+      </a>
+    </nav>
+
+    <!-- Right: Social + CTA -->
+    <div class="flex items-center gap-3">
+      <div class="hidden sm:flex items-center gap-2">
+        <a href="https://www.instagram.com/foodstuckers.sthlm/" target="_blank" rel="noopener noreferrer" aria-label="Instagram"
+           class="flex items-center justify-center w-8 h-8 rounded-lg text-[#94a3b8] hover:text-[#e8f5e9] hover:bg-[rgba(255,255,255,0.05)] transition-all">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect><path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path><line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line></svg>
+        </a>
+        <a href="https://www.linkedin.com/in/jenson3006/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn"
+           class="flex items-center justify-center w-8 h-8 rounded-lg text-[#94a3b8] hover:text-[#e8f5e9] hover:bg-[rgba(255,255,255,0.05)] transition-all">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
+        </a>
+        <a href="https://github.com/JensonNg" target="_blank" rel="noopener noreferrer" aria-label="GitHub"
+           class="flex items-center justify-center w-8 h-8 rounded-lg text-[#94a3b8] hover:text-[#e8f5e9] hover:bg-[rgba(255,255,255,0.05)] transition-all">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
+        </a>
+      </div>
+      <a href="#contact" class="btn-primary text-sm px-4 py-1.5">Let's talk</a>
     </div>
   </div>
 </header>

--- a/src/_includes/partials/skills.html
+++ b/src/_includes/partials/skills.html
@@ -1,0 +1,94 @@
+<section id="skills" class="mb-6">
+  <div class="section-card">
+    <!-- Section Header -->
+    <div class="section-card__header">
+      <div class="flex items-center gap-6">
+        <div class="flex items-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline></svg>
+          <span class="badge">Skills</span>
+        </div>
+        <div>
+          <h2 class="text-2xl font-semibold text-[#e8f5e9]">Skills &amp; Expertise</h2>
+          <p class="text-[#94a3b8] text-sm mt-0.5">Technical skills and creative competencies</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section Body -->
+    <div class="section-card__body">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+
+        <div class="flex flex-col gap-3">
+          <h3 class="text-[#22c55e] text-sm font-semibold uppercase tracking-wider">Content &amp; Creative</h3>
+          <ul class="flex flex-col gap-2">
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Short-form Video Production
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Instagram Reels &amp; TikTok
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Video Editing (Premiere, CapCut)
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Visual Storytelling
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Brand Identity &amp; Design
+            </li>
+          </ul>
+        </div>
+
+        <div class="flex flex-col gap-3">
+          <h3 class="text-[#22c55e] text-sm font-semibold uppercase tracking-wider">Marketing &amp; Strategy</h3>
+          <ul class="flex flex-col gap-2">
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Growth Marketing
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              UX Writing &amp; Copywriting
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Content Strategy
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Social Media Management
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Campaign Management
+            </li>
+          </ul>
+        </div>
+
+        <div class="flex flex-col gap-3">
+          <h3 class="text-[#22c55e] text-sm font-semibold uppercase tracking-wider">Languages</h3>
+          <ul class="flex flex-col gap-2">
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              English (Fluent)
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Swedish (Conversational)
+            </li>
+            <li class="flex items-center gap-2 text-[#94a3b8] text-sm">
+              <span class="w-1.5 h-1.5 rounded-full bg-[#22c55e] shrink-0"></span>
+              Vietnamese (Native)
+            </li>
+          </ul>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</section>

--- a/src/scss/global.css
+++ b/src/scss/global.css
@@ -2,12 +2,95 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+:root {
+  --color-bg: #0a0f0d;
+  --color-surface: rgba(255,255,255,0.03);
+  --color-border: rgba(255,255,255,0.08);
+  --color-text-primary: #e8f5e9;
+  --color-text-secondary: #94a3b8;
+  --color-accent: #22c55e;
+  --color-accent-dark: #16a34a;
+}
+
 .link {
-  @apply text-rose-500;
+  color: var(--color-accent);
 }
 
 .hover-link:hover {
- @apply text-rose-600 transition-all duration-100;
+  color: var(--color-accent-dark);
+  transition: all 0.1s;
+}
+
+.section-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 16px;
+  box-shadow: 0 8px 32px 0 rgba(0,0,0,0.4);
+  margin-bottom: 1.5rem;
+}
+
+.section-card__header {
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+}
+
+.section-card__body {
+  padding: 1.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  background: rgba(34,197,94,0.1);
+  border: 1px solid rgba(34,197,94,0.2);
+  border-radius: 9999px;
+  color: var(--color-accent);
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-accent);
+  color: #052e16;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  transition: background 0.15s;
+}
+
+.btn-primary:hover {
+  background: var(--color-accent-dark);
+  color: #f0fdf4;
+}
+
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--color-accent);
+  border: 1px solid var(--color-accent);
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  transition: all 0.15s;
+}
+
+.btn-outline:hover {
+  background: rgba(34,197,94,0.1);
 }
 
 .block-equation {


### PR DESCRIPTION
- Switch to dark theme (#0a0f0d bg, #22c55e green accent) matching Figma design
- Update hero: new headline "Xin Chào! / I'm Son Nguyen", Growth Marketing Strategist role badge, updated bio and CTA buttons
- Rebuild navigation: SN logo, My Information/My Work links, social icons, Let's talk button
- Add About Me section: bio, profile photo, stats (6+ yrs, 1500+ followers, 8+ orgs, 3 languages), differentiators
- Add Content Creation section: Instagram Reels and LinkedIn Posts grids with placeholders
- Add Skills & Expertise section: Content/Creative, Marketing/Strategy, Languages
- Add Contact section: contact info (email, phone, location), areas of collaboration, contact form
- Restyle Education and Experience as dark-themed section cards with hover states
- Restyle Featured Projects with dark card and grayscale-to-color image hover effect
- Update footer: SN logo, address (Vega/Handen/Stockholm), quick links, social icons

https://claude.ai/code/session_01MHL63CtQfqMohBetZEPKbV