### PR TITLE
Add portfolio pages, Sowilo rune logo, and brand kit

### DIFF
--- a/public/brand/logo-horizontal-dark.svg
+++ b/public/brand/logo-horizontal-dark.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="80" viewBox="0 0 400 80">
+  <defs>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C"/>
+      <stop offset="50%" stop-color="#F2994A"/>
+      <stop offset="100%" stop-color="#F2C94C"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#F2994A" stop-opacity="0.3"/>
+    </linearGradient>
+    <radialGradient id="bg" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="rgba(242,201,76,0.06)"/>
+      <stop offset="100%" stop-color="#111111"/>
+    </radialGradient>
+  </defs>
+  <rect x="2" y="2" width="76" height="76" rx="19" fill="url(#bg)" stroke="url(#ring)" stroke-width="2"/>
+  <path d="M19 6 L43 32 L19 32 L43 74" stroke="url(#gold)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <text x="98" y="38" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="700" letter-spacing="2">SON</text>
+  <text x="98" y="66" fill="#CCCCCC" font-family="Inter, Helvetica, Arial, sans-serif" font-size="30" font-weight="300" letter-spacing="2">NGUYEN</text>
+</svg>

--- a/public/brand/logo-horizontal-tagline-dark.svg
+++ b/public/brand/logo-horizontal-tagline-dark.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="64" viewBox="0 0 480 64">
+  <defs>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C"/>
+      <stop offset="50%" stop-color="#F2994A"/>
+      <stop offset="100%" stop-color="#F2C94C"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#F2994A" stop-opacity="0.3"/>
+    </linearGradient>
+    <radialGradient id="bg" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="rgba(242,201,76,0.06)"/>
+      <stop offset="100%" stop-color="#111111"/>
+    </radialGradient>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="15" fill="url(#bg)" stroke="url(#ring)" stroke-width="1.5"/>
+  <path d="M15 5 L33 24 L15 24 L33 57" stroke="url(#gold)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <text x="78" y="30" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="700" letter-spacing="1.5">SON NGUYEN</text>
+  <text x="78" y="50" fill="#888888" font-family="Inter, Helvetica, Arial, sans-serif" font-size="12" font-weight="400" letter-spacing="3">GROWTH MARKETING STRATEGIST</text>
+</svg>

--- a/public/brand/logo-stacked-dark.svg
+++ b/public/brand/logo-stacked-dark.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="280" viewBox="0 0 200 280">
+  <defs>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C"/>
+      <stop offset="50%" stop-color="#F2994A"/>
+      <stop offset="100%" stop-color="#F2C94C"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#F2994A" stop-opacity="0.3"/>
+    </linearGradient>
+    <radialGradient id="bg" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="rgba(242,201,76,0.06)"/>
+      <stop offset="100%" stop-color="#111111"/>
+    </radialGradient>
+  </defs>
+  <rect x="30" y="0" width="140" height="140" rx="34" fill="url(#bg)" stroke="url(#ring)" stroke-width="2.5"/>
+  <path d="M65 11 L114 57 L65 57 L114 129" stroke="url(#gold)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <text x="100" y="174" text-anchor="middle" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="700" letter-spacing="4">SON</text>
+  <text x="100" y="204" text-anchor="middle" fill="#CCCCCC" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="300" letter-spacing="4">NGUYEN</text>
+  <line x1="40" y1="220" x2="160" y2="220" stroke="#F2C94C" stroke-opacity="0.3" stroke-width="1"/>
+  <text x="100" y="244" text-anchor="middle" fill="#888888" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="4">GROWTH MARKETING</text>
+  <text x="100" y="260" text-anchor="middle" fill="#888888" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="4">STRATEGIST</text>
+</svg>

--- a/public/brand/son-nguyen-logo-kit.svg
+++ b/public/brand/son-nguyen-logo-kit.svg
@@ -1,0 +1,255 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="2400" viewBox="0 0 1600 2400">
+  <defs>
+    <!-- Brand Colors -->
+    <linearGradient id="gold-gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C"/>
+      <stop offset="50%" stop-color="#F2994A"/>
+      <stop offset="100%" stop-color="#F2C94C"/>
+    </linearGradient>
+    <linearGradient id="gold-gradient-h" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#F2C94C"/>
+      <stop offset="50%" stop-color="#F2994A"/>
+      <stop offset="100%" stop-color="#F2C94C"/>
+    </linearGradient>
+    <linearGradient id="ring-grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#F2994A" stop-opacity="0.3"/>
+    </linearGradient>
+    <radialGradient id="bg-dark" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="rgba(242,201,76,0.06)"/>
+      <stop offset="100%" stop-color="#111111"/>
+    </radialGradient>
+    <radialGradient id="bg-light" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="rgba(242,201,76,0.08)"/>
+      <stop offset="100%" stop-color="#FAFAFA"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Background -->
+  <rect width="1600" height="2400" fill="#0A0A0A"/>
+
+  <!-- ============================================ -->
+  <!-- TITLE -->
+  <!-- ============================================ -->
+  <text x="800" y="80" text-anchor="middle" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="700" letter-spacing="6">SON NGUYEN - BRAND LOGO KIT</text>
+  <line x1="200" y1="100" x2="1400" y2="100" stroke="#F2C94C" stroke-opacity="0.2" stroke-width="1"/>
+
+  <!-- ============================================ -->
+  <!-- 1. PRIMARY LOGO MARK (Dark BG) -->
+  <!-- ============================================ -->
+  <text x="200" y="170" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="3">01 — PRIMARY MARK (DARK)</text>
+
+  <!-- Large primary mark -->
+  <g transform="translate(400, 220)">
+    <rect x="0" y="0" width="200" height="200" rx="48" fill="url(#bg-dark)" stroke="url(#ring-grad)" stroke-width="3"/>
+    <path d="M50 16 L110 80 L50 80 L110 184" stroke="url(#gold-gradient)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <path d="M50 16 L110 80 L50 80 L110 184" stroke="#F2C94C" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.15" transform="translate(2, 2)"/>
+  </g>
+
+  <!-- Medium -->
+  <g transform="translate(700, 270)">
+    <rect x="0" y="0" width="120" height="120" rx="30" fill="url(#bg-dark)" stroke="url(#ring-grad)" stroke-width="2"/>
+    <path d="M30 10 L66 48 L30 48 L66 110" stroke="url(#gold-gradient)" stroke-width="5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+
+  <!-- Small -->
+  <g transform="translate(900, 310)">
+    <rect x="0" y="0" width="64" height="64" rx="16" fill="url(#bg-dark)" stroke="url(#ring-grad)" stroke-width="1.5"/>
+    <path d="M16 5 L35 26 L16 26 L35 59" stroke="url(#gold-gradient)" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+
+  <!-- Favicon size -->
+  <g transform="translate(1020, 330)">
+    <rect x="0" y="0" width="32" height="32" rx="8" fill="url(#bg-dark)" stroke="url(#ring-grad)" stroke-width="1"/>
+    <path d="M8 3 L18 13 L8 13 L18 29" stroke="#F2C94C" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+
+  <text x="1020" y="385" fill="#666" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">32px</text>
+  <text x="900" y="395" fill="#666" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">64px</text>
+  <text x="700" y="410" fill="#666" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">120px</text>
+  <text x="400" y="440" fill="#666" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">200px</text>
+
+  <!-- ============================================ -->
+  <!-- 2. PRIMARY LOGO MARK (Light BG) -->
+  <!-- ============================================ -->
+  <text x="200" y="510" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="3">02 — PRIMARY MARK (LIGHT)</text>
+
+  <!-- Light background area -->
+  <rect x="200" y="530" width="1200" height="250" rx="16" fill="#F5F5F5"/>
+
+  <g transform="translate(400, 560)">
+    <rect x="0" y="0" width="180" height="180" rx="44" fill="url(#bg-light)" stroke="#E0E0E0" stroke-width="2"/>
+    <path d="M45 14 L99 72 L45 72 L99 166" stroke="#1A1A1A" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <path d="M45 14 L99 72 L45 72 L99 166" stroke="#F2994A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.3" transform="translate(1.5, 1.5)"/>
+  </g>
+
+  <g transform="translate(700, 600)">
+    <rect x="0" y="0" width="100" height="100" rx="24" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1.5"/>
+    <path d="M25 8 L55 40 L25 40 L55 92" stroke="#1A1A1A" stroke-width="4.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+
+  <g transform="translate(880, 620)">
+    <rect x="0" y="0" width="64" height="64" rx="16" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+    <path d="M16 5 L35 26 L16 26 L35 59" stroke="#1A1A1A" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  </g>
+
+  <!-- ============================================ -->
+  <!-- 3. HORIZONTAL LOCKUP (Dark) -->
+  <!-- ============================================ -->
+  <text x="200" y="850" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="3">03 — HORIZONTAL LOCKUP (DARK)</text>
+
+  <!-- Full name lockup large -->
+  <g transform="translate(200, 880)">
+    <rect x="0" y="0" width="80" height="80" rx="20" fill="url(#bg-dark)" stroke="url(#ring-grad)" stroke-width="2"/>
+    <path d="M20 6 L44 32 L20 32 L44 74" stroke="url(#gold-gradient)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="100" y="40" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="32" font-weight="700" letter-spacing="2">SON</text>
+    <text x="100" y="68" fill="#CCCCCC" font-family="Inter, Helvetica, Arial, sans-serif" font-size="32" font-weight="300" letter-spacing="2">NGUYEN</text>
+  </g>
+
+  <!-- With tagline -->
+  <g transform="translate(200, 1000)">
+    <rect x="0" y="0" width="60" height="60" rx="15" fill="url(#bg-dark)" stroke="url(#ring-grad)" stroke-width="1.5"/>
+    <path d="M15 5 L33 24 L15 24 L33 55" stroke="url(#gold-gradient)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="78" y="30" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="22" font-weight="700" letter-spacing="1.5">SON NGUYEN</text>
+    <text x="78" y="52" fill="#888888" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="400" letter-spacing="3">GROWTH MARKETING STRATEGIST</text>
+  </g>
+
+  <!-- Compact -->
+  <g transform="translate(750, 1000)">
+    <rect x="0" y="0" width="44" height="44" rx="11" fill="url(#bg-dark)" stroke="url(#ring-grad)" stroke-width="1"/>
+    <path d="M11 4 L24 18 L11 18 L24 40" stroke="url(#gold-gradient)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="56" y="20" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="700" letter-spacing="1">SON</text>
+    <text x="56" y="38" fill="#CCCCCC" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="300" letter-spacing="1">NGUYEN</text>
+  </g>
+
+  <!-- ============================================ -->
+  <!-- 4. HORIZONTAL LOCKUP (Light) -->
+  <!-- ============================================ -->
+  <text x="200" y="1120" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="3">04 — HORIZONTAL LOCKUP (LIGHT)</text>
+
+  <rect x="200" y="1140" width="1200" height="160" rx="16" fill="#F5F5F5"/>
+
+  <g transform="translate(240, 1160)">
+    <rect x="0" y="0" width="80" height="80" rx="20" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="2"/>
+    <path d="M20 6 L44 32 L20 32 L44 74" stroke="#1A1A1A" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="100" y="40" fill="#1A1A1A" font-family="Inter, Helvetica, Arial, sans-serif" font-size="32" font-weight="700" letter-spacing="2">SON</text>
+    <text x="100" y="68" fill="#555555" font-family="Inter, Helvetica, Arial, sans-serif" font-size="32" font-weight="300" letter-spacing="2">NGUYEN</text>
+  </g>
+
+  <g transform="translate(700, 1175)">
+    <rect x="0" y="0" width="48" height="48" rx="12" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="1"/>
+    <path d="M12 4 L26 19 L12 19 L26 44" stroke="#1A1A1A" stroke-width="2.8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="60" y="22" fill="#1A1A1A" font-family="Inter, Helvetica, Arial, sans-serif" font-size="18" font-weight="700" letter-spacing="1.5">SON NGUYEN</text>
+    <text x="60" y="40" fill="#888888" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11" font-weight="400" letter-spacing="3">GROWTH MARKETING STRATEGIST</text>
+  </g>
+
+  <!-- ============================================ -->
+  <!-- 5. STACKED / VERTICAL LOCKUP -->
+  <!-- ============================================ -->
+  <text x="200" y="1380" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="3">05 — VERTICAL / STACKED LOCKUP</text>
+
+  <!-- Dark stacked -->
+  <g transform="translate(300, 1420)">
+    <rect x="30" y="0" width="140" height="140" rx="34" fill="url(#bg-dark)" stroke="url(#ring-grad)" stroke-width="2.5"/>
+    <path d="M65 11 L114 57 L65 57 L114 129" stroke="url(#gold-gradient)" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="100" y="172" text-anchor="middle" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="700" letter-spacing="4">SON</text>
+    <text x="100" y="200" text-anchor="middle" fill="#CCCCCC" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="300" letter-spacing="4">NGUYEN</text>
+    <line x1="40" y1="216" x2="160" y2="216" stroke="#F2C94C" stroke-opacity="0.3" stroke-width="1"/>
+    <text x="100" y="236" text-anchor="middle" fill="#888888" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="4">GROWTH MARKETING</text>
+    <text x="100" y="250" text-anchor="middle" fill="#888888" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="4">STRATEGIST</text>
+  </g>
+
+  <!-- Light stacked -->
+  <rect x="620" y="1400" width="320" height="310" rx="16" fill="#F5F5F5"/>
+  <g transform="translate(700, 1420)">
+    <rect x="30" y="0" width="140" height="140" rx="34" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="2"/>
+    <path d="M65 11 L114 57 L65 57 L114 129" stroke="#1A1A1A" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="100" y="172" text-anchor="middle" fill="#1A1A1A" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="700" letter-spacing="4">SON</text>
+    <text x="100" y="200" text-anchor="middle" fill="#555555" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="300" letter-spacing="4">NGUYEN</text>
+    <line x1="40" y1="216" x2="160" y2="216" stroke="#CCCCCC" stroke-width="1"/>
+    <text x="100" y="236" text-anchor="middle" fill="#999999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="4">GROWTH MARKETING</text>
+    <text x="100" y="250" text-anchor="middle" fill="#999999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10" font-weight="400" letter-spacing="4">STRATEGIST</text>
+  </g>
+
+  <!-- ============================================ -->
+  <!-- 6. MARK ONLY — FLAT / NO CONTAINER -->
+  <!-- ============================================ -->
+  <text x="200" y="1770" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="3">06 — MARK ONLY (NO CONTAINER)</text>
+
+  <!-- Gold on dark -->
+  <g transform="translate(300, 1800)">
+    <path d="M0 0 L50 50 L0 50 L50 130" stroke="url(#gold-gradient)" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="25" y="155" text-anchor="middle" fill="#666" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">Gold on Dark</text>
+  </g>
+
+  <!-- White on dark -->
+  <g transform="translate(500, 1800)">
+    <path d="M0 0 L50 50 L0 50 L50 130" stroke="#FFFFFF" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="25" y="155" text-anchor="middle" fill="#666" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">White on Dark</text>
+  </g>
+
+  <!-- Dark on light -->
+  <rect x="650" y="1790" width="150" height="180" rx="12" fill="#F5F5F5"/>
+  <g transform="translate(700, 1800)">
+    <path d="M0 0 L50 50 L0 50 L50 130" stroke="#1A1A1A" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="25" y="155" text-anchor="middle" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">Dark on Light</text>
+  </g>
+
+  <!-- Gold on light -->
+  <rect x="880" y="1790" width="150" height="180" rx="12" fill="#F5F5F5"/>
+  <g transform="translate(930, 1800)">
+    <path d="M0 0 L50 50 L0 50 L50 130" stroke="#D4A017" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+    <text x="25" y="155" text-anchor="middle" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">Gold on Light</text>
+  </g>
+
+  <!-- ============================================ -->
+  <!-- 7. COLOR PALETTE -->
+  <!-- ============================================ -->
+  <text x="200" y="2060" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="3">07 — BRAND COLOR PALETTE</text>
+
+  <!-- Solar Gold -->
+  <rect x="200" y="2090" width="160" height="100" rx="12" fill="#F2C94C"/>
+  <text x="280" y="2130" text-anchor="middle" fill="#111111" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700">Solar Gold</text>
+  <text x="280" y="2150" text-anchor="middle" fill="#333333" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">#F2C94C</text>
+  <text x="280" y="2165" text-anchor="middle" fill="#333333" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10">Primary</text>
+
+  <!-- Amber -->
+  <rect x="380" y="2090" width="160" height="100" rx="12" fill="#F2994A"/>
+  <text x="460" y="2130" text-anchor="middle" fill="#111111" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700">Amber</text>
+  <text x="460" y="2150" text-anchor="middle" fill="#333333" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">#F2994A</text>
+  <text x="460" y="2165" text-anchor="middle" fill="#333333" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10">Secondary</text>
+
+  <!-- Warm Orange -->
+  <rect x="560" y="2090" width="160" height="100" rx="12" fill="#EB5757"/>
+  <text x="640" y="2130" text-anchor="middle" fill="#FFFFFF" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700">Warm Red</text>
+  <text x="640" y="2150" text-anchor="middle" fill="#EEEEEE" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">#EB5757</text>
+  <text x="640" y="2165" text-anchor="middle" fill="#EEEEEE" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10">Tertiary</text>
+
+  <!-- Deep Black -->
+  <rect x="740" y="2090" width="160" height="100" rx="12" fill="#111111" stroke="#333" stroke-width="1"/>
+  <text x="820" y="2130" text-anchor="middle" fill="#CCCCCC" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700">Deep Black</text>
+  <text x="820" y="2150" text-anchor="middle" fill="#999999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">#111111</text>
+  <text x="820" y="2165" text-anchor="middle" fill="#999999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10">Background</text>
+
+  <!-- Off White -->
+  <rect x="920" y="2090" width="160" height="100" rx="12" fill="#F5F5F5" stroke="#E0E0E0" stroke-width="1"/>
+  <text x="1000" y="2130" text-anchor="middle" fill="#333333" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700">Off White</text>
+  <text x="1000" y="2150" text-anchor="middle" fill="#555555" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">#F5F5F5</text>
+  <text x="1000" y="2165" text-anchor="middle" fill="#555555" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10">Light BG</text>
+
+  <!-- Muted -->
+  <rect x="1100" y="2090" width="160" height="100" rx="12" fill="#888888"/>
+  <text x="1180" y="2130" text-anchor="middle" fill="#111111" font-family="Inter, Helvetica, Arial, sans-serif" font-size="13" font-weight="700">Muted</text>
+  <text x="1180" y="2150" text-anchor="middle" fill="#222222" font-family="Inter, Helvetica, Arial, sans-serif" font-size="11">#888888</text>
+  <text x="1180" y="2165" text-anchor="middle" fill="#222222" font-family="Inter, Helvetica, Arial, sans-serif" font-size="10">Body Text</text>
+
+  <!-- ============================================ -->
+  <!-- 8. TYPOGRAPHY REFERENCE -->
+  <!-- ============================================ -->
+  <text x="200" y="2260" fill="#999" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="600" letter-spacing="3">08 — TYPOGRAPHY</text>
+
+  <text x="200" y="2300" fill="#F2C94C" font-family="Inter, Helvetica, Arial, sans-serif" font-size="36" font-weight="700">Inter Bold — Headlines</text>
+  <text x="200" y="2340" fill="#CCCCCC" font-family="Inter, Helvetica, Arial, sans-serif" font-size="28" font-weight="300">Inter Light — Subheadings</text>
+  <text x="200" y="2375" fill="#888888" font-family="Inter, Helvetica, Arial, sans-serif" font-size="16" font-weight="400">Inter Regular — Body copy, descriptions, and UI text</text>
+
+</svg>

--- a/public/brand/sowilo-mark-dark.svg
+++ b/public/brand/sowilo-mark-dark.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <defs>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C"/>
+      <stop offset="50%" stop-color="#F2994A"/>
+      <stop offset="100%" stop-color="#F2C94C"/>
+    </linearGradient>
+    <linearGradient id="ring" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#F2994A" stop-opacity="0.3"/>
+    </linearGradient>
+    <radialGradient id="bg" cx="0.3" cy="0.3" r="0.8">
+      <stop offset="0%" stop-color="rgba(242,201,76,0.06)"/>
+      <stop offset="100%" stop-color="#111111"/>
+    </radialGradient>
+  </defs>
+  <rect x="4" y="4" width="192" height="192" rx="48" fill="url(#bg)" stroke="url(#ring)" stroke-width="3"/>
+  <path d="M50 16 L110 80 L50 80 L110 184" stroke="url(#gold)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/public/brand/sowilo-mark-light.svg
+++ b/public/brand/sowilo-mark-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="200" viewBox="0 0 200 200">
+  <rect x="4" y="4" width="192" height="192" rx="48" fill="#FFFFFF" stroke="#E0E0E0" stroke-width="2"/>
+  <path d="M50 16 L110 80 L50 80 L110 184" stroke="#1A1A1A" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/public/brand/sowilo-standalone.svg
+++ b/public/brand/sowilo-standalone.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="200" viewBox="0 0 100 200">
+  <defs>
+    <linearGradient id="gold" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#F2C94C"/>
+      <stop offset="50%" stop-color="#F2994A"/>
+      <stop offset="100%" stop-color="#F2C94C"/>
+    </linearGradient>
+  </defs>
+  <path d="M10 5 L60 75 L10 75 L60 195" stroke="url(#gold)" stroke-width="8" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,9 +15,7 @@ export function Footer() {
             <div className="flex items-start gap-2 text-muted-foreground">
               <MapPin className="w-4 h-4 mt-1 flex-shrink-0" />
               <address className="not-italic">
-                Vega, Handen<br />
-                13648, Stockholm<br />
-                Sweden
+                Stockholm, Sweden
               </address>
             </div>
           </div>

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -4,45 +4,104 @@ interface LogoProps {
 }
 
 export function Logo({ size = 'md', variant = 'default' }: LogoProps) {
-  const sizeClasses = {
-    sm: 'w-8 h-8 text-sm',
-    md: 'w-10 h-10 text-base',
-    lg: 'w-12 h-12 text-lg'
+  const sizeMap = {
+    sm: 32,
+    md: 40,
+    lg: 48
   };
+
+  const px = sizeMap[size];
 
   if (variant === 'minimal') {
     return (
-      <div className={`${sizeClasses[size]} relative flex items-center justify-center`}>
-        <span className="font-bold text-primary">SN</span>
-      </div>
+      <svg width={px} height={px} viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <SowiloRune />
+      </svg>
     );
   }
 
   return (
-    <div className={`${sizeClasses[size]} relative group cursor-pointer`}>
-      {/* Background gradient circles */}
-      <div className="absolute inset-0 bg-gradient-to-br from-primary/20 to-secondary/20 rounded-full transition-all duration-300 group-hover:scale-110 group-hover:from-primary/30 group-hover:to-secondary/30" />
-      <div className="absolute inset-0.5 bg-gradient-to-br from-secondary/15 to-tertiary/15 rounded-full transition-all duration-300 group-hover:scale-105" />
-      
-      {/* Main logo container */}
-      <div className="relative w-full h-full bg-gradient-to-br from-background to-accent rounded-full border border-primary/30 flex items-center justify-center transition-all duration-300 group-hover:border-primary/50 group-hover:shadow-lg group-hover:shadow-primary/20" style={{ backdropFilter: 'blur(8px)' }}>
-        {/* Letters */}
-        <div className="relative flex items-center justify-center">
-          <span className="font-bold text-primary transition-all duration-300 group-hover:scale-110">
-            S
-          </span>
-          <span className="font-bold text-secondary ml-0.5 transition-all duration-300 group-hover:scale-110 group-hover:text-primary">
-            N
-          </span>
-        </div>
-        
-        {/* Subtle accent dot */}
-        <div className="absolute top-1 right-1 w-1 h-1 bg-tertiary rounded-full opacity-60 transition-all duration-300 group-hover:opacity-100 group-hover:bg-primary" />
-      </div>
-      
-      {/* Floating accent rings on hover */}
-      <div className="absolute inset-0 rounded-full border border-primary/0 transition-all duration-500 group-hover:border-primary/20 group-hover:scale-125" />
-      <div className="absolute inset-0 rounded-full border border-secondary/0 transition-all duration-700 group-hover:border-secondary/15 group-hover:scale-150" />
+    <div className="relative group cursor-pointer">
+      {/* Thunder glow on hover */}
+      <div className="absolute inset-0 rounded-xl bg-primary/0 blur-xl transition-all duration-500 group-hover:bg-primary/25 group-hover:scale-150" />
+
+      <svg
+        width={px}
+        height={px}
+        viewBox="0 0 48 48"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        className="relative transition-transform duration-300 group-hover:scale-110"
+      >
+        {/* Rounded square background */}
+        <rect
+          x="2"
+          y="2"
+          width="44"
+          height="44"
+          rx="12"
+          fill="url(#bg-gradient)"
+          stroke="url(#ring-gradient)"
+          strokeWidth="1.5"
+          opacity="0.9"
+        />
+
+        <SowiloRune />
+
+        <defs>
+          <linearGradient id="ring-gradient" x1="0" y1="0" x2="48" y2="48">
+            <stop stopColor="var(--color-primary)" stopOpacity="0.5" />
+            <stop offset="1" stopColor="var(--color-secondary)" stopOpacity="0.3" />
+          </linearGradient>
+          <radialGradient id="bg-gradient" cx="0.3" cy="0.3" r="0.8">
+            <stop stopColor="rgba(242,201,76,0.06)" />
+            <stop offset="1" stopColor="rgba(17,17,17,0.98)" />
+          </radialGradient>
+        </defs>
+      </svg>
+
+      {/* Floating ring on hover */}
+      <div className="absolute inset-0 rounded-xl border border-primary/0 transition-all duration-500 group-hover:border-primary/15 group-hover:scale-[1.3]" />
     </div>
+  );
+}
+
+/**
+ * Sowilo rune (ᛊ) — the Elder Futhark rune for "S"
+ * Shaped like a lightning bolt / thunder strike
+ */
+function SowiloRune() {
+  return (
+    <g>
+      {/* Main Sowilo rune — angular lightning bolt shape */}
+      <path
+        d="M18 8 L30 20 L18 20 L30 40"
+        stroke="url(#rune-gradient)"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+
+      {/* Subtle glow/echo stroke for depth */}
+      <path
+        d="M18 8 L30 20 L18 20 L30 40"
+        stroke="var(--color-primary)"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+        opacity="0.2"
+        transform="translate(0.8, 0.8)"
+      />
+
+      <defs>
+        <linearGradient id="rune-gradient" x1="18" y1="8" x2="30" y2="40">
+          <stop stopColor="var(--color-primary)" />
+          <stop offset="0.5" stopColor="var(--color-secondary)" />
+          <stop offset="1" stopColor="var(--color-primary)" />
+        </linearGradient>
+      </defs>
+    </g>
   );
 }


### PR DESCRIPTION
## Summary
- **Services page** with expandable creative packages and How I Work section
- **Experience Timeline** — interactive, color-coded, expandable entries replacing old card layout
- **Projects** updated with real marketing brand experiences and metrics from portfolio
- **Contact form** functional via Formsubmit.co with GDPR consent checkbox
- **Privacy Policy** page (GDPR-compliant)
- **Hero section** with portrait photos, gradient masks, and keyword cloud tags
- **CV & Certificates** section with in-page PDF preview modal on About page
- **Sowilo rune logo** (ᛊ) — Viking S as thunder bolt mark, replacing generic SN text
- **Brand logo kit** — full SVG suite (dark/light marks, horizontal/stacked lockups, color palette)
- **Footer** simplified to Stockholm, Sweden
- Multi-page SPA routing with React Router

## Test plan
- [ ] Verify all routes load: /, /about, /projects, /services, /contact, /privacy
- [ ] Test contact form submission and GDPR consent flow
- [ ] Check experience timeline expand/collapse interactions
- [ ] Verify PDF preview modal on About page CV section
- [ ] Test responsive layout on mobile, tablet, desktop
- [ ] Import brand SVGs into Figma to verify quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)